### PR TITLE
Make info use optional extra parameter

### DIFF
--- a/libraries/Redis.php
+++ b/libraries/Redis.php
@@ -389,9 +389,13 @@ class CI_Redis {
 	 * of the server info instead of a nasty string.
 	 * @return 	array
 	 */
-	public function info()
+	public function info($extra=false)
 	{
-		$response = $this->command('INFO');
+		if ($extra!=false){
+			$response = $this->command('INFO '.$extra);
+		} else {
+			$response = $this->command('INFO');
+		}
 		$data = array();
 		$lines = explode(self::CRLF, $response);
 

--- a/libraries/Redis.php
+++ b/libraries/Redis.php
@@ -389,9 +389,9 @@ class CI_Redis {
 	 * of the server info instead of a nasty string.
 	 * @return 	array
 	 */
-	public function info($section=false)
+	public function info($section=FALSE)
 	{
-		if ($section!=false)
+		if ($section!=FALSE)
 		{
 			$response = $this->command('INFO '.$section);
 		}

--- a/libraries/Redis.php
+++ b/libraries/Redis.php
@@ -389,11 +389,14 @@ class CI_Redis {
 	 * of the server info instead of a nasty string.
 	 * @return 	array
 	 */
-	public function info($extra=false)
+	public function info($section=false)
 	{
-		if ($extra!=false){
-			$response = $this->command('INFO '.$extra);
-		} else {
+		if ($section!=false)
+		{
+			$response = $this->command('INFO '.$section);
+		}
+		else 
+		{
 			$response = $this->command('INFO');
 		}
 		$data = array();

--- a/tests/Redis_test.php
+++ b/tests/Redis_test.php
@@ -97,6 +97,12 @@ class RedisTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(isset($info['redis_version']));
 		$this->assertTrue(isset($info['process_id']));
 	}
+		public function test_info_section()
+	{
+		$info = $this->redis->info("memory");
+		$this->assertTrue(isset($info['used_memory_human']));
+		$this->assertFalse(isset($info['process_id']));
+	}
 
 	/**
 	 * Plain text command


### PR DESCRIPTION
The Redis Info call accepts a second parameter to only return part of the info. E.g. Info Memory. This pull request should make the library accept that.
