### PR TITLE
More important fixes and edge cases

### DIFF
--- a/libraries/Redis.php
+++ b/libraries/Redis.php
@@ -209,10 +209,6 @@ class CI_Redis {
 			
 			} // end while value_length is greater than 0
 
-			// send line endings with multi-block send commands
-			fwrite($this->_connection, "\r\n", 2);
-
-
 		} // end else (value length is greather than 8192)
 
 		// read our request into a variable

--- a/libraries/Redis.php
+++ b/libraries/Redis.php
@@ -204,16 +204,17 @@ class CI_Redis {
 				// how much is left to send?
 				$value_length = $value_length - $sendSize;
 
-				// remove data sent from outgoing dataA
+				// remove data sent from outgoing data
 				$request = substr($request, $sendSize, $value_length);
 			
 			} // end while value_length is greater than 0
 
-		} // end else (value length is greather than 8192)
+		} // end else (value length is greater than 8192)
 
 		// read our request into a variable
 		$return = $this->_read_request();
 
+		// trim errant endings from returned data
 		$return = rtrim($return);
 
 		
@@ -371,18 +372,15 @@ class CI_Redis {
 		
 		} // end while value_length is greater than 0
 
-
 	} // end else (value length is greather than 8192)
 
 
 
-        // Make sure to remove the new line and carriage from the socket buffer
-        //$response = rtrim($response);
 
 	// clear the socket in case anything remains in there
 	$this->_clear_socket();
 
-        return isset($response) ? $response : FALSE;
+	return isset($response) ? $response : FALSE;
     }
 
 	/**


### PR DESCRIPTION
I just found a few more things!  Take this next request too!

Like I said before, I am abusing this library with hundreds of calls per second in a process that runs for months at a time - so I am actively doing work and testing this stuff.

The most important thing I fixed in the extra code today is a problem with very long responses.  It is possible for fread to not pull the entire string from the socket, which cuts off a reply. 

Additionally, it is possible for leftover data in a socket to end up in the keys area and cause a false NULL return in the case that interprets the response type.  I added some code that reads until it finds the next appropriate character.  It isn't perfect but prevents a lot of bad responses.

That and the logic I used for blocking large sends was broken.
