### PR TITLE
Adding fix for data sometimes not being read fully when below 8192 bytes...

### DIFF
--- a/libraries/Redis.php
+++ b/libraries/Redis.php
@@ -7,7 +7,7 @@
  * @package        	CodeIgniter
  * @category    	Libraries
  * @author        	Joël Cox
- * @version			v0.4
+ * @version			v0.4.1
  * @link 			https://github.com/joelcox/codeigniter-redis
  * @link			http://joelcox.nl
  * @license         http://www.opensource.org/licenses/mit-license.html

--- a/spark.info
+++ b/spark.info
@@ -1,6 +1,6 @@
 # Spark spec
 name: redis
-version: 0.3.0
+version: 0.4.1
 compatibility: 2.0.0
 dependencies: []
 tags: ["nosql", "database", "data store", "key-value store"]


### PR DESCRIPTION
I think this is the fix to the issue I repoted.  Issue #47 

It was still possible for fread to not fully return all the requested data in one read when responses were less than 8192 bytes long.
