### PR TITLE
method _bulk_reply is not returning the correct data

### DIFF
--- a/libraries/Redis.php
+++ b/libraries/Redis.php
@@ -322,7 +322,12 @@ class CI_Redis {
 		// fully return from redis and enter into socket.
         $value_length = (int) fgets($this->_connection);
 
-        if ($value_length <= 0) return NULL;
+	if ($value_length <= 0) {
+		if ($value_length == 0) {
+			fgets($this->_connection);
+		}
+		return NULL;
+	}
 
         $response = '';
 


### PR DESCRIPTION
Redis protocol sends a "CRLF" when it returns a string with zero length ($0), but when it returns a string "-1" ($-1) length it does not have a "CRLF". Solution is to remove "CRLF" when its a zero length string.
